### PR TITLE
Small fix to make generated Dockerfile valid again.

### DIFF
--- a/kdc
+++ b/kdc
@@ -170,7 +170,7 @@ function stopDocker {
 
 # Render docker container image.
 function buildImage {
-	local RENDER_PRINCIPAL="kadmin -l add --password=PASSWORD --use-defaults PRINCIPAL"
+	local RENDER_PRINCIPAL="RUN kadmin -l add --password=PASSWORD --use-defaults PRINCIPAL"
 	local EXPORT_KEYTAB="RUN kadmin -l ext_keytab -k /etc/docker-kdc/krb5.keytab"
 
 	# Use a temporary file for the add principal directives.
@@ -205,8 +205,8 @@ function buildImage {
 
 	# Use --no-cache switch to prevent broken builds due to outdated caches.
 	docker build --no-cache -t $DOCKERIMAGE .
-        rm -f Dockerfile
-        rm -f krb5.conf
+	rm -f Dockerfile
+	rm -f krb5.conf
 }
 
 


### PR DESCRIPTION
The problem was that the following was generated in the intermediate Dockerfile by ./kdc run:

```
# Add kerberos principal/s.
kadmin -l add --password=matilda --use-defaults tillt/baymax.example.com@EXAMPLE.COM
```

Instead of:

```
# Add kerberos principal/s.
RUN kadmin -l add --password=matilda --use-defaults tillt/baymax.example.com@EXAMPLE.COM
```
