### PR TITLE
Allow docker cache; update apt just before install

### DIFF
--- a/kdc
+++ b/kdc
@@ -204,8 +204,7 @@ function buildImage {
 		-e "s=REALM_NAME=$KDC_REALM_NAME=g"			\
 		"$KDC_TEMPLATES_DIR/krb5.conf" >krb5.conf
 
-	# Use --no-cache switch to prevent broken builds due to outdated caches.
-	docker build --no-cache -t $DOCKERIMAGE .
+	docker build -t $DOCKERIMAGE .
 	rm -f Dockerfile
 	rm -f krb5.conf
 }

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:14.04
 MAINTAINER Till Toenshoff <@ttoenshoff>
 
-RUN apt-get -y update
+ARG DEBIAN_FRONTEND=noninteractive
 
 ADD krb5.conf /etc/krb5.conf
 
 RUN echo package heimdal/realm string REALM | debconf-set-selections
-RUN apt-get -y install heimdal-kdc
-RUN apt-get -y install libsasl2-modules-gssapi-heimdal
+RUN apt-get -y update && \
+    apt-get -y install heimdal-kdc libsasl2-modules-gssapi-heimdal
 
 EXPOSE	88
 


### PR DESCRIPTION
Also reduced the number of docker layers by putting all apt-get commands in one RUN directive. 

This can make `./kdc build` quite a bit faster, but should still prevent broken builds due to outdated apt caches.
